### PR TITLE
feat: codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+codecov:
+  notify:
+    after_n_builds: 6
+  strict_yaml_branch: main
+
+coverage:
+  range: '50...90'
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+        informational: true
+    patch: off
+
+flag_management:
+  default_rules:
+    carryforward: true
+    statuses:
+      - type: project
+        target: auto
+        threshold: 2%
+        informational: true
+
+comment:
+  require_changes: true
+  after_n_builds: 6


### PR DESCRIPTION
### Please describe the changes this PR makes and why it should be merged:
Adds codecov as follows:

- Project level status reports only for now, set to informational to not fail CI at the moment. If we ever do enable patch status reports, we should probably only do it at the global level.
- Per package somewhat strict on coverage droop but as a whole a little more lenient
- Package separation is done via flags, packages that don't yet have coverage are automatically skipped (action is smart)
- Codecov will only post a report on PRs affecting coverage since there will be many that don't right now
- Will always use the configuration located in the main branch for a little more security
- Only runs on the orgs repo
- Status and versioning classification:

### Status and versioning classification?
